### PR TITLE
Add Assert.notNull() for AuthenticationProvider additions.

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2TokenEndpointConfigurer.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2TokenEndpointConfigurer.java
@@ -45,6 +45,7 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
 
 /**
  * Configurer for the OAuth 2.0 Token Endpoint.
@@ -87,6 +88,7 @@ public final class OAuth2TokenEndpointConfigurer extends AbstractOAuth2Configure
 	 * @return the {@link OAuth2TokenEndpointConfigurer} for further configuration
 	 */
 	public OAuth2TokenEndpointConfigurer authenticationProvider(AuthenticationProvider authenticationProvider) {
+		Assert.notNull(authenticationProvider, "authenticationProvider cannot be null");
 		this.authenticationProviders.add(authenticationProvider);
 		return this;
 	}


### PR DESCRIPTION
If we accidentally provide a null authenticationProvider configured via:

```
            authorizationServerConfigurer
                    .tokenEndpoint(tokenEndpoint -> {
                        tokenEndpoint.accessTokenRequestConverter(new DelegatingAuthenticationConverter(
                            converters))
                            .authenticationProvider(nullAuthProvider)
                        }
                    );
```

We get an NPE during the authenticationProviders.add(authenticationProvider) statement in Oauth2TokenEndpointConfigurer.  The error stack is quite unclear where the NPE is coming from, requiring time-consuming IDE troubleshooting:

```
Caused by: java.lang.NullPointerException: null
	at org.springframework.security.config.annotation.SecurityConfigurerAdapter$CompositeObjectPostProcessor.postProcess(SecurityConfigurerAdapter.java:117)
	at org.springframework.security.config.annotation.SecurityConfigurerAdapter.postProcess(SecurityConfigurerAdapter.java:79)
	at org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.AbstractOAuth2Configurer.postProcess(AbstractOAuth2Configurer.java:42)
	at org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2TokenEndpointConfigurer.lambda$init$0(OAuth2TokenEndpointConfigurer.java:129)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
```

This PR adds an Assert.notNull, similar to many places elsewhere in the project, creating a much clearer stack trace:

```
Caused by: java.lang.IllegalArgumentException: authenticationProvider cannot be null

	at org.springframework.util.Assert.notNull(Assert.java:201)
	at org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2TokenEndpointConfigurer.authenticationProvider(OAuth2TokenEndpointConfigurer.java:91)
	at com.mycompany.myproject.config.SecurityConfig$NewAuthServerConfigurationAdapter.lambda$configure$0(SecurityConfig.java:228)
	at org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2AuthorizationServerConfigurer.tokenEndpoint(OAuth2AuthorizationServerConfigurer.java:162)
	at com.mycompany.myproject.config.SecurityConfig$NewAuthServerConfigurationAdapter.configure(SecurityConfig.java:223)
```